### PR TITLE
[FIX] Prototype-pollution on "rdf-graph-array"

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,6 +206,10 @@ inherits(rdf.Graph, rdf.AbstractGraph)
 
 rdf.Graph.prototype.add = function (quad) {
   var i = rdf.Graph.index(quad)
+  
+  if (i.g === '__proto__' || i.g === 'constructor' || i.g === 'prototype') {
+    return this._gspo;
+  }
 
   this._gspo[i.g] = this._gspo[i.g] || {}
   this._gspo[i.g][i.s] = this._gspo[i.g][i.s] || {}

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ rdf.Graph.prototype.add = function (quad) {
   var i = rdf.Graph.index(quad)
   
   if (i.g === '__proto__' || i.g === 'constructor' || i.g === 'prototype') {
-    return this._gspo;
+    return this;
   }
 
   this._gspo[i.g] = this._gspo[i.g] || {}


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-rdf-graph-array

### ⚙️ Description *

The `rdf-graph-array` module was vulnerable against `prototype pollution` which could lead to `dangerous behaviors`

### 💻 Technical Description *

I applied the same fix used to patch a `prototype pollution` issue in `lodash`  (https://github.com/lodash/lodash/pull/4759/files)

### 🐛 Proof of Concept (PoC) *
1. Create the PoC file:
```js
// poc.js
var Graph = require("rdf-graph-array").Graph;
var g = new Graph();
g.add({graph: "foo", subject: "__proto__", "predicate": "toString", "object": "huntr.dev"});
console.log({}.toString);
```
2. `node poc.js`
3. The output will show `huntr.dev`

### 🔥 Proof of Fix (PoF) *

Same with fixed version ... returns a normal object

### 👍 User Acceptance Testing (UAT)

Seems all OK 👍 